### PR TITLE
fix lb association_id variable

### DIFF
--- a/README.yaml
+++ b/README.yaml
@@ -66,6 +66,11 @@ usage: |-
       public_ip_enabled = true
       ip_version        = "IPv4"
 
+      # Backend Pool
+      is_enable_backend_pool              = false
+      network_interaface_id_association   = ""
+      ip_configuration_name_association   = ""
+
       remote_port = {
         ssh = ["Tcp", "22"]
       }

--- a/_example/example.tf
+++ b/_example/example.tf
@@ -81,10 +81,9 @@ module "load-balancer" {
   ip_version        = "IPv4"
 
   # Backend Pool
-  is_enable_backend_pool              = false
-  network_interaface_id_association   = ""
-  ip_configuration_name_association   = ""
-  backend_address_pool_id_association = ""
+  is_enable_backend_pool            = false
+  network_interaface_id_association = ""
+  ip_configuration_name_association = ""
 
   remote_port = {
     ssh   = ["Tcp", "22"]

--- a/main.tf
+++ b/main.tf
@@ -116,5 +116,5 @@ resource "azurerm_network_interface_backend_address_pool_association" "default" 
   count                   = var.is_enable_backend_pool ? 1 : 0
   network_interface_id    = var.network_interaface_id_association
   ip_configuration_name   = var.ip_configuration_name_association
-  backend_address_pool_id = var.backend_address_pool_id_association
+  backend_address_pool_id = azurerm_lb_backend_address_pool.load-balancer.id
 }

--- a/variables.tf
+++ b/variables.tf
@@ -261,9 +261,3 @@ variable "ip_configuration_name_association" {
   type        = string
   default     = "Tcp"
 }
-
-variable "backend_address_pool_id_association" {
-  description = "(Required) Backend Addrees Pool for Network Interaface Association with Load Balancer."
-  type        = string
-  default     = "Tcp"
-}


### PR DESCRIPTION
## what
* Fixed the "azurerm_network_interface_backend_address_pool_association" resource that backend pool id was getting by variable. 
* Added local "azurerm_lb_backend_address_pool.load-balancer" resource in that.

## why
* Pointless variable to use for backend address pool of load balancer.

## references
* Deepak sir.
