### PR TITLE
added count and list variable in NI to lb backend association resource

### DIFF
--- a/_example/example.tf
+++ b/_example/example.tf
@@ -81,9 +81,9 @@ module "load-balancer" {
   ip_version        = "IPv4"
 
   # Backend Pool
-  is_enable_backend_pool            = false
-  network_interaface_id_association = ""
-  ip_configuration_name_association = ""
+  is_enable_backend_pool = false
+  # network_interaface_id_association = ""
+  # ip_configuration_name_association = ""
 
   remote_port = {
     ssh   = ["Tcp", "22"]

--- a/main.tf
+++ b/main.tf
@@ -113,8 +113,8 @@ resource "azurerm_lb_rule" "load-balancer" {
 }
 
 resource "azurerm_network_interface_backend_address_pool_association" "default" {
-  count                   = var.is_enable_backend_pool ? 1 : 0
-  network_interface_id    = var.network_interaface_id_association
-  ip_configuration_name   = var.ip_configuration_name_association
+  count                   = var.is_enable_backend_pool ? length(var.network_interaface_id_association) : 0
+  network_interface_id    = var.network_interaface_id_association[count.index]
+  ip_configuration_name   = var.ip_configuration_name_association[count.index]
   backend_address_pool_id = azurerm_lb_backend_address_pool.load-balancer.id
 }

--- a/variables.tf
+++ b/variables.tf
@@ -252,12 +252,12 @@ variable "is_enable_backend_pool" {
 
 variable "network_interaface_id_association" {
   description = "(Required) Network Interaface id for Network Interface Association with Load Balancer."
-  type        = string
-  default     = "Tcp"
+  type        = list(string)
+  default     = [""]
 }
 
 variable "ip_configuration_name_association" {
   description = "(Required) Ip Configuration name for Network Interaface Association with Load Balancer."
-  type        = string
-  default     = "Tcp"
+  type        = list(string)
+  default     = [""]
 }


### PR DESCRIPTION
## what
* Added the count in Network Interface to Backend Poll association resource.

## why
* If multiple network security groups or network interface is used then can't create because of single resource creation.

## references
* Referred Terraform's official site.
