### PR TITLE
[Hurodata-51] fix - private ip can be allocate to load balancer

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -52,8 +52,12 @@ resource "azurerm_lb" "load-balancer" {
   sku                 = var.lb_sku
 
   frontend_ip_configuration {
-    name                 = var.frontend_name
-    public_ip_address_id = try(azurerm_public_ip.default[0].id, "")
+    name                          = var.frontend_name
+    private_ip_address            = var.frontend_private_ip_address
+    private_ip_address_allocation = var.frontend_private_ip_address_allocation
+    private_ip_address_version    = var.frontend_private_ip_address_version
+    public_ip_address_id          = try(azurerm_public_ip.default[0].id, "")
+    subnet_id                     = var.frontend_subnet_id
   }
 
   timeouts {

--- a/variables.tf
+++ b/variables.tf
@@ -188,6 +188,13 @@ variable "frontend_private_ip_address_allocation" {
   default     = "Dynamic"
 }
 
+variable "frontend_private_ip_address_version" {
+  description = "(Optional) The version of IP that the Private IP Address is. Possible values are `IPv4` or `IPv6`."
+  type        = string
+  default     = null
+}
+
+
 variable "frontend_subnet_id" {
   description = "(Optional) Frontend subnet id to use when in private mode"
   type        = string

--- a/versions.tf
+++ b/versions.tf
@@ -1,6 +1,6 @@
 # Terraform version
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.3.6"
 }
 
 terraform {


### PR DESCRIPTION
## what
* Public IP can be allocate to Azure load balancer.

## why
* Bug fixed.

## references
* Link to any supporting jira issues or helpful documentation to add some context (e.g. stackoverflow).
* Use `closes #123`, if this PR closes a Jira issue `#123`
